### PR TITLE
Update ICONMAP (.gif to .png)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 2.2a1 (unreleased)
 ------------------
 
+- Update ICONMAP (.gif to .png).
+  [mathias.leimgruber]
+
 - Move content type profile definitions from Products.CMFPlone into here.
   (Merge of PLIP 12344)
   [davisagli et al.]

--- a/Products/ATContentTypes/config.py
+++ b/Products/ATContentTypes/config.py
@@ -80,8 +80,8 @@ WORKFLOW_TOPIC = 'folder_workflow'
 WORKFLOW_CRITERIA = ''
 
 ## icon map used for overwriting ATFile icons
-ICONMAP = {'application/pdf': 'pdf_icon.gif',
-           'image': 'image_icon.gif'}
+ICONMAP = {'application/pdf': 'pdf_icon.png',
+           'image': 'image_icon.png'}
 
 MIME_ALIAS = {
     'plain': 'text/plain',


### PR DESCRIPTION
Both gifs are deprecated. Plone 4.3 does not load the deprecated skin layer by default. 
