### PR TITLE
Added missing translations domain

### DIFF
--- a/Products/ATContentTypes/configure.zcml
+++ b/Products/ATContentTypes/configure.zcml
@@ -2,7 +2,8 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:five="http://namespaces.zope.org/five"
-    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="atcontenttypes">
 
   <include zcml:condition="installed Products.LinguaPlone" 
            package="Products.LinguaPlone" />


### PR DESCRIPTION
As the genericsetup zcml stanza has a title, tests complain about a missing i18n:domain on configure.zcml.

This commit adds it.
