### PR TITLE
Allow exporting ATTopic

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 2.1.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Re-enable exporting of ATTopics, which was disabled in mid 2009 due to broken
+  marshaling of PrincipiaFolderish types, which is now fixed in CMFCore.
+  [matthewwilkes]
 
 
 2.1.14 (2013-12-07)

--- a/Products/ATContentTypes/configure.zcml
+++ b/Products/ATContentTypes/configure.zcml
@@ -40,4 +40,16 @@
     for=".criteria.path.ATPathCriterion"
     />
 
+  <adapter
+      factory="Products.GenericSetup.content.DAVAwareFileAdapter"
+      provides="Products.GenericSetup.interfaces.IFilesystemExporter"
+      for="Products.ATContentTypes.criteria.base.NonRefCatalogContent"
+      />
+
+  <adapter
+      factory="Products.GenericSetup.content.DAVAwareFileAdapter"
+      provides="Products.GenericSetup.interfaces.IFilesystemImporter"
+      for="Products.ATContentTypes.criteria.base.NonRefCatalogContent"
+      />
+
 </configure>

--- a/Products/ATContentTypes/content/topic.py
+++ b/Products/ATContentTypes/content/topic.py
@@ -147,7 +147,7 @@ class ATTopic(ATCTFolder):
 
     use_folder_tabs = 0
 
-    implements(IATTopic, IDisabledExport)
+    implements(IATTopic)
 
     # Enable marshalling via WebDAV/FTP
     __dav_marshall__ = True

--- a/Products/ATContentTypes/content/topic.py
+++ b/Products/ATContentTypes/content/topic.py
@@ -32,7 +32,6 @@ from Products.ATContentTypes.config import PROJECTNAME
 from Products.ATContentTypes.content.base import registerATCT
 from Products.ATContentTypes.content.base import ATCTFolder
 from Products.ATContentTypes.criteria import _criterionRegistry
-from Products.ATContentTypes.exportimport.content import IDisabledExport
 from Products.ATContentTypes.content.schemata import ATContentTypeSchema
 from Products.ATContentTypes.content.schemata import finalizeATCTSchema
 from Products.ATContentTypes.interfaces import IATTopic

--- a/Products/ATContentTypes/criteria/schemata.py
+++ b/Products/ATContentTypes/criteria/schemata.py
@@ -1,6 +1,7 @@
 from Products.Archetypes.atapi import Schema
 from Products.Archetypes.atapi import StringField
 from Products.Archetypes.atapi import IdWidget
+from Products.Archetypes.atapi import RFC822Marshaller
 from Products.Archetypes.atapi import StringWidget
 from Products.ATContentTypes.permission import ChangeTopics
 
@@ -37,4 +38,6 @@ ATBaseCriterionSchema = Schema((
                                            "Short Name is part of the item's web address.")
                     ),
                 ),
-    ))
+    ),
+    marshall=RFC822Marshaller()
+)

--- a/Products/ATContentTypes/exportimport/content.py
+++ b/Products/ATContentTypes/exportimport/content.py
@@ -3,8 +3,8 @@ from zope.interface import Interface
 
 from Products.GenericSetup.interfaces import IFilesystemExporter
 
-# TODO: This is a temporary hack to allow disabling exporting of some
-# content types until all of them support proper exporting
+# BBB: Leaving this old 'temporary hack' in, in case people are relying on it.
+# It's no longer used in core.
 
 
 class IDisabledExport(Interface):


### PR DESCRIPTION
ATTopic had exporting disabled as the resultant files were broken due to problems in exporting folderish and unrefereancable types. These have been fixed in the relevant packages, so there's no reason to prevent Topics being exported anymore.