### PR TITLE
add CSRF token in createObject redirection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 2.2.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add CSRF authenticator in createObject script
+  [ebrehault]
 
 
 2.2.5 (2015-05-04)

--- a/Products/ATContentTypes/skins/ATContentTypes/createObject.cpy
+++ b/Products/ATContentTypes/skins/ATContentTypes/createObject.cpy
@@ -17,6 +17,8 @@ response = REQUEST.response
 response.setHeader('Expires', 'Sat, 01 Jan 2000 00:00:00 GMT')
 response.setHeader('Cache-Control', 'no-cache')
 
+authenticator = context.restrictedTraverse("@@authenticator")
+
 if id is None:
     id = context.generateUniqueId(type_name)
 else:
@@ -37,7 +39,7 @@ if not fti.queryMethodID('edit'):
 if type_name in context.portal_factory.getFactoryTypes():
     new_url = 'portal_factory/' + type_name + '/' + id
     if state.getStatus() != 'success_no_edit':
-        new_url = new_url + '/edit'
+        new_url = new_url + '/edit?_authenticator='  + authenticator.token()
     state.set(status='factory', next_action='redirect_to:string:%s' % new_url)
     # If there's an issue with object creation, let the factory handle it
     return state


### PR DESCRIPTION
## Issue
- install an Archetypes-based content-type on Plone 5,
- click Add new <the content>
- we are redirected to the CSRF confirm page
- and only once confirmed, we access the expected `/portal_factory/<content>/<id>/atct_edit` page

## Reason
When the `createObject` script redirects to `/portal_factory/<content>/<id>/atct_edit`, there is no `_authenticator` parameter

## Proposed solution
Add a token to the redirect url.
It does work, but I am not totally sure that's the right approach. Review appreciated.