### PR TITLE
Update permission.py

### DIFF
--- a/Products/ATContentTypes/permission.py
+++ b/Products/ATContentTypes/permission.py
@@ -22,8 +22,6 @@ setDefaultRoles(AddTopics, TOPIC_ROLES)
 ChangeTopics = 'Change portal topics'
 setDefaultRoles(ChangeTopics, CHANGE_TOPIC_ROLES)
 
-ChangeEvents = 'Change portal events'
-setDefaultRoles(ChangeEvents, ('Manager', 'Site Administrator', 'Owner',))
 
 ModifyConstrainTypes = "Modify constrain types"
 setDefaultRoles(ModifyConstrainTypes,


### PR DESCRIPTION
removed Change portal events  as it's usage was removed in svn revision r104169
issues mentioned: Remove unused permission "Change portal events". plone/Products.CMFPlone#1975
@jensens