### PR TITLE
Add a fallback for processQueue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Add a conditional import of ``processQueue`` as this package is still used on 5.0.
+  [gforcada]
 
 
 2.3.4 (2017-04-01)

--- a/Products/ATContentTypes/tests/test_criteria.py
+++ b/Products/ATContentTypes/tests/test_criteria.py
@@ -21,9 +21,14 @@ from Products.ATContentTypes.criteria.sort import ATSortCriterion
 from Products.ATContentTypes.interfaces import IATTopicCriterion
 from Products.ATContentTypes.tests import atcttestcase
 from zope.interface.verify import verifyObject
-from Products.CMFCore.indexing import processQueue
 
 import unittest
+
+try:
+    from Products.CMFCore.indexing import processQueue
+except ImportError:
+    def processQueue():
+        pass
 
 
 tests = []


### PR DESCRIPTION
It is being used on 5.0, so a conditional import must bee used.