### PR TITLE
Fix traversing in portal_factory with url-quoted type-name

### DIFF
--- a/Products/ATContentTypes/tests/atctftestcase.py
+++ b/Products/ATContentTypes/tests/atctftestcase.py
@@ -69,7 +69,7 @@ class ATCTIntegrationTestCase(IntegrationTestCase):
         response = self.publish(
             '%s/createObject?type_name=%s&_authenticator=%s' % (
                 self.folder_path, self.portal_type, auth),
-            self.basic_auth)
+            self.basic_auth, handle_errors=False)
 
         self.assertEqual(response.getStatus(), 302)  # Redirect to edit
 
@@ -81,7 +81,8 @@ class ATCTIntegrationTestCase(IntegrationTestCase):
 
         # Perform the redirect
         edit_form_path = body[len(self.layer['request'].SERVER_URL):]
-        response = self.publish(edit_form_path, self.basic_auth)
+        response = self.publish(
+            edit_form_path, self.basic_auth, handle_errors=False)
         self.assertEqual(response.getStatus(), 200)  # OK
         temp_id = body.split('/')[-2]
 

--- a/Products/ATContentTypes/tool/factory.py
+++ b/Products/ATContentTypes/tool/factory.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from six.moves.urllib.parse import unquote
+
 from AccessControl import ClassSecurityInfo
 from AccessControl import getSecurityManager
 from AccessControl import Owned
@@ -445,6 +447,11 @@ class FactoryTool(PloneBaseTool, UniqueObject, SimpleItem):
         # method call in which case the traversal stack will not have been
         # cleared by __before_publishing_traverse__
         name = str(name)  # fix unicode weirdness
+        # In Zope4 the url is url-quoted during redirects so " " becomes "%20"
+        # Since we have "News Item" this fails when looking for "News%20Item".
+        if '%' in name:
+            name = unquote(name)
+
         types_tool = getToolByName(self, 'portal_types')
         if name not in types_tool.listContentTypes():
             # not a type name -- do the standard thing

--- a/news/63.bugfix
+++ b/news/63.bugfix
@@ -1,0 +1,2 @@
+Fix traversing in portal_factory with url-quoted type-name. During redirecting in Zope4 spaces in the URL (e.g. in "News Item") get quoted to `%20`. This prevented finding the portal_type in `__bobo_traverse__`. See https://github.com/plone/buildout.coredev/pull/586
+[pbauer]


### PR DESCRIPTION
During redirecting spaces in the URL (e.g. in "News Item") get quoted to `%20`. This prevents finding the portal_type in `__bobo_traverse__`.
See https://github.com/plone/buildout.coredev/pull/586